### PR TITLE
Add TagRef and FileRef and implement tag attach in `Shelf`

### DIFF
--- a/file-manager/src/main.rs
+++ b/file-manager/src/main.rs
@@ -1,10 +1,27 @@
+use crate::tag::{Tag, TagRef};
 use shelf::shelf::Shelf;
 use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
 
+mod query;
 mod shelf;
+mod tag;
 
 fn main() {
-    println!("Hello, world!");
     // Test
-    Shelf::new(PathBuf::from("C:\\Users\\Alessandro\\Desktop\\Projects\\Tag-Based File Manager\\Automated Test Procedures\\Tests\\Workspaces\\Generated\\Directory"));
+    //Shelf::new(PathBuf::from("C:\\Users\\Alessandro\\Desktop\\Projects\\Tag-Based File Manager\\Automated Test Procedures\\Tests\\Workspaces\\Generated\\Directory"));
+//    let mut shelf = Shelf::new(PathBuf::from(
+//        "/home/yamabiko/Projects/ebi/Automated Test Procedures/Tests/Workspaces/Generated/Test/",
+//    ))
+//    .unwrap();
+//    let tag = Tag::default();
+//
+//    let tref = TagRef {
+//        tag_ref: Arc::new(RwLock::new(tag)),
+//    };
+//
+//    let file = PathBuf::from("/home/yamabiko/Projects/ebi/Automated Test Procedures/Tests/Workspaces/Generated/Test/4EZ3WpsO/hiLQFdlc.dat");
+//    if let Err(e) = shelf.attach(file, tref) {
+//        eprintln!("{:?}", e);
+//    }
 }

--- a/file-manager/src/query.rs
+++ b/file-manager/src/query.rs
@@ -1,0 +1,8 @@
+#[derive(Debug)]
+pub struct Query {}
+
+// TODO: define appropriate errors, include I/O, etc.
+pub enum QueryErr {
+    SyntaxError, // The Query is incorrectly formatted
+    KeyError,    // The Query uses tags which do not exist in the Shelf
+}

--- a/file-manager/src/shelf/file.rs
+++ b/file-manager/src/shelf/file.rs
@@ -1,0 +1,148 @@
+use crate::tag::TagRef;
+use chrono::{DateTime, Utc};
+use std::cmp::Ordering;
+use std::collections::BTreeSet;
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+#[cfg(windows)]
+use std::os::windows::fs::MetadataExt;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::RwLock;
+
+#[derive(Debug, Clone)]
+pub struct FileRef {
+    pub file_ref: Rc<RwLock<File>>,
+}
+
+#[derive(Debug)]
+pub struct File {
+    path: PathBuf,
+    hash: u64,
+    metadata: FileMetadata,
+    tags: BTreeSet<TagRef>,
+    dtags: BTreeSet<TagRef>,
+}
+
+#[derive(Debug)]
+pub struct FileMetadata {
+    size: u64,
+    readonly: bool,
+    modified: Option<DateTime<Utc>>,
+    accessed: Option<DateTime<Utc>>,
+    created: Option<DateTime<Utc>>,
+    unix: Option<UnixMetadata>,
+    windows: Option<WindowsMetadata>,
+}
+
+#[derive(Debug)]
+struct UnixMetadata {
+    permissions: u32,
+    uid: u32,
+    gid: u32,
+}
+
+#[derive(Debug)]
+struct WindowsMetadata {
+    attributes: u32,
+}
+
+impl FileMetadata {
+    pub fn new(path: &PathBuf) -> Self {
+        let meta = match std::fs::metadata(path) {
+            Ok(meta) => meta,
+            Err(_) => {
+                return FileMetadata {
+                    size: 0,
+                    readonly: false,
+                    modified: None,
+                    accessed: None,
+                    created: None,
+                    unix: None,
+                    windows: None,
+                }
+            }
+        };
+
+        FileMetadata {
+            size: meta.len(),
+            readonly: meta.permissions().readonly(),
+            modified: meta.modified().ok().map(DateTime::<Utc>::from),
+            accessed: meta.accessed().ok().map(DateTime::<Utc>::from),
+            created: meta.created().ok().map(DateTime::<Utc>::from),
+
+            #[cfg(unix)]
+            unix: Some(UnixMetadata {
+                permissions: meta.mode(),
+                uid: meta.uid(),
+                gid: meta.gid(),
+            }),
+            #[cfg(windows)]
+            unix: None,
+
+            #[cfg(windows)]
+            windows: Some(WindowsMetadata {
+                attributes: meta.file_attributes(),
+            }),
+            #[cfg(unix)]
+            windows: None,
+        }
+    }
+}
+
+impl PartialEq for FileRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.file_ref.read().unwrap().path == other.file_ref.read().unwrap().path
+    }
+}
+
+impl Eq for FileRef {}
+
+impl PartialOrd for FileRef {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(
+            self.file_ref
+                .read()
+                .unwrap()
+                .metadata
+                .modified
+                .cmp(&other.file_ref.read().unwrap().metadata.modified),
+        )
+    }
+}
+
+impl Ord for FileRef {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.file_ref
+            .read()
+            .unwrap()
+            .metadata
+            .modified
+            .cmp(&other.file_ref.read().unwrap().metadata.modified)
+    }
+}
+
+impl File {
+    pub fn new(
+        path: PathBuf,
+        tags: BTreeSet<TagRef>,
+        dtags: BTreeSet<TagRef>,
+        metadata: FileMetadata,
+    ) -> Self {
+        File {
+            path,
+            hash: 0,
+            metadata,
+            tags,
+            dtags,
+        }
+    }
+
+    pub fn add_tag(&mut self, tag: TagRef) -> bool {
+        self.tags.insert(tag)
+    }
+
+    pub fn remove_tag(&mut self, tag: TagRef) -> bool {
+        self.tags.remove(&tag)
+    }
+}

--- a/file-manager/src/shelf/mod.rs
+++ b/file-manager/src/shelf/mod.rs
@@ -1,1 +1,3 @@
+mod file;
+mod node;
 pub mod shelf;

--- a/file-manager/src/shelf/node.rs
+++ b/file-manager/src/shelf/node.rs
@@ -1,0 +1,69 @@
+use crate::shelf::file::{File, FileMetadata, FileRef};
+use crate::tag::TagRef;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::io;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::sync::RwLock;
+
+#[derive(Debug, Default)]
+pub struct Node {
+    pub files: HashMap<PathBuf, FileRef>,
+    pub tags: HashMap<TagRef, BTreeSet<FileRef>>, // TODO: this should be changed to BTreeSet later
+    pub dtags: HashSet<TagRef>,                   // directory level tags, to be applied down
+    pub directories: HashMap<PathBuf, Node>, // untagged: set of untagged files, support structure
+}
+
+impl Node {
+    pub fn new(path: PathBuf) -> Result<Self, io::Error> {
+        let entries = std::fs::read_dir(&path)?
+            .map(|res| res.map(|e| e.path()))
+            .collect::<Result<Vec<_>, io::Error>>()?;
+        let (dir_paths, file_paths): (Vec<_>, Vec<_>) =
+            entries.into_iter().partition(|path| path.is_dir());
+        let files = file_paths
+            .into_iter()
+            .map(|file_path| {
+                (
+                    file_path.clone(),
+                    FileRef {
+                        file_ref: Rc::new(RwLock::new(File::new(
+                            file_path.clone(),
+                            BTreeSet::new(),
+                            BTreeSet::new(),
+                            FileMetadata::new(&file_path),
+                        ))),
+                    },
+                )
+            })
+            .collect::<HashMap<PathBuf, FileRef>>();
+        let directories = dir_paths
+            .into_iter()
+            .map(|dir| {
+                (
+                    dir.strip_prefix(&path).unwrap().to_path_buf(),
+                    Node::new(dir).unwrap(),
+                )
+            })
+            .collect::<HashMap<PathBuf, Node>>();
+        Ok(Node {
+            files,
+            tags: HashMap::new(),
+            dtags: HashSet::new(),
+            directories,
+        })
+    }
+
+    pub fn attach_dtag(&mut self, tag: TagRef) -> bool {
+        self.dtags.insert(tag.clone())
+    }
+
+    pub fn detach_dtag(&mut self, tag: TagRef) -> bool {
+        self.dtags.remove(&tag)
+    }
+
+    pub fn attach(&mut self, tag: TagRef, file: FileRef) -> bool {
+        let set = self.tags.entry(tag).or_insert_with(|| BTreeSet::new());
+        set.insert(file.clone())
+    }
+}

--- a/file-manager/src/shelf/shelf.rs
+++ b/file-manager/src/shelf/shelf.rs
@@ -1,222 +1,92 @@
-use chrono::{DateTime, Utc};
-use std::collections::{BTreeSet, HashMap, HashSet};
-use std::fs::{self, DirEntry};
-use std::os::windows::fs::MetadataExt;
+use crate::query::{Query, QueryErr};
+use crate::shelf::file::File;
+use crate::shelf::node::Node;
+use crate::tag::TagRef;
+use std::io;
 use std::path::PathBuf;
-use std::rc::Rc;
 use std::result::Result;
-use std::time::UNIX_EPOCH;
-use std::{io, rc};
-/*
-#[cfg(unix)]
-use std::os::unix::fs::MetadataExt as unixMetadata;
-#[cfg(windows)]
-use std::os::windows::fs::MetadataExt as windowsMetadata;
-*/
 
 // Shelf
 #[derive(Debug)]
 pub struct Shelf {
-    root: Node,
+    pub root: Node,
+    root_path: PathBuf,
     // String = Workspace identifier + Global
-    ownership: HashMap<Tag, HashSet<String>>,
 }
 
 impl Shelf {
     pub fn new(path: PathBuf) -> Result<Self, io::Error> {
         Ok(Shelf {
-            root: Node::new(path)?,
-            ownership: HashMap::new(),
+            root: Node::new(path.clone())?,
+            root_path: path,
         })
     }
 
     pub async fn refresh(&self) -> Result<bool, io::Error> {
         todo!();
-        // Must also update the 'modifiied', 'size' fields in Metadata
     }
 
     pub fn query(&self, query: Query) -> Result<Vec<&'static File>, QueryErr> {
         todo!();
     }
 
-    pub fn insert(&self, file: PathBuf, tag: Tag) -> Result<bool, UpdateErr> {
-        todo!();
-    }
+    pub fn attach(&mut self, file: PathBuf, tag: TagRef) -> Result<bool, UpdateErr> {
+        let stripped_path = file
+            .strip_prefix(&self.root_path)
+            .map_err(|_| UpdateErr::PathNotFound)?
+            .parent();
 
-    pub fn delete(&self, file: Option<PathBuf>, tag: Tag) -> Result<bool, UpdateErr> {
-        todo!();
-    }
-}
+        let mut node_v: Vec<(PathBuf, Node)> = Vec::new();
+        // Take ownership
+        let mut curr_node = std::mem::take(&mut self.root);
 
-// Node
-#[derive(Debug)]
-struct Node {
-    files: HashMap<PathBuf, Rc<File>>,
-    tags: HashMap<Tag, Rc<File>>,
-    node_tags: BTreeSet<&'static Tag>,   // Directory level tags
-    directories: HashMap<PathBuf, Node>, // untagged: set of untagged files, support structure
-}
-
-impl Node {
-    pub fn new(path: PathBuf) -> Result<Self, io::Error> {
-        let entries = fs::read_dir(path)?
-            .map(|res| res.map(|e| e.path()))
-            .collect::<Result<Vec<_>, io::Error>>()?;
-        let (dir_paths, file_paths): (Vec<_>, Vec<_>) =
-            entries.into_iter().partition(|path| path.is_dir());
-        let files = file_paths
-            .into_iter()
-            .map(|file_path| {
-                (
-                    file_path.clone(),
-                    Rc::new(File::new(
-                        file_path.clone(),
-                        BTreeSet::new(),
-                        BTreeSet::new(),
-                        FileMetadata::new(&file_path),
-                    )),
-                )
-            })
-            .collect::<HashMap<PathBuf, Rc<File>>>();
-        let directories = dir_paths
-            .into_iter()
-            .map(|dir| (dir.clone(), Node::new(dir.clone()).unwrap()))
-            .collect::<HashMap<PathBuf, Node>>();
-        Ok(Node {
-            files,
-            tags: HashMap::new(),
-            node_tags: BTreeSet::new(),
-            directories,
-        })
-    }
-
-    pub fn add_node_tag(&mut self, tag: &'static Tag) -> bool {
-        self.node_tags.insert(tag)
-    }
-
-    pub fn remove_node_tag(&mut self, tag: Tag) -> bool {
-        self.node_tags.remove(&tag)
-    }
-}
-
-// Tag
-#[derive(Debug, Eq, PartialOrd, PartialEq, Ord)]
-pub struct Tag {
-    name: String,
-    parent: Option<&'static Tag>,
-    subtags: BTreeSet<&'static Tag>, //Parent tags in a query will be substituted by a disjunctive expression of themselves and their subtags
-}
-
-#[derive(Debug)]
-pub struct FileMetadata {
-    size: u64,
-    readonly: bool,
-    modified: Option<DateTime<Utc>>,
-    accessed: Option<DateTime<Utc>>,
-    created: Option<DateTime<Utc>>,
-    unix: Option<UnixMetadata>,
-    windows: Option<WindowsMetadata>,
-}
-
-#[derive(Debug)]
-struct UnixMetadata {
-    permissions: u32,
-    uid: u32,
-    gid: u32,
-}
-
-#[derive(Debug)]
-struct WindowsMetadata {
-    attributes: u32,
-}
-
-impl FileMetadata {
-    pub fn new(path: &PathBuf) -> Self {
-        let meta = match fs::metadata(path) {
-            Ok(meta) => meta,
-            Err(_) => {
-                return FileMetadata {
-                    size: 0,
-                    readonly: false,
-                    modified: None,
-                    accessed: None,
-                    created: None,
-                    unix: None,
-                    windows: None,
+        // if stripped_path is none, file must be self.root
+        if let Some(path) = stripped_path {
+            for dir in path.ancestors() {
+                // skip empty path (root dir)
+                // this is needed because ancestors gives
+                // see https://github.com/rust-lang/rust/issues/54927
+                if dir.as_os_str().is_empty() {
+                    continue;
                 }
+
+                let child = curr_node.directories.remove(dir).unwrap();
+
+                // Store the current node (ownership moved)
+                node_v.push((dir.to_path_buf(), curr_node));
+
+                // Move to the child node
+                curr_node = child;
             }
-        };
-
-        FileMetadata {
-            size: meta.len(),
-            readonly: meta.permissions().readonly(),
-            modified: meta.modified().ok().map(DateTime::<Utc>::from),
-            accessed: meta.accessed().ok().map(DateTime::<Utc>::from),
-            created: meta.created().ok().map(DateTime::<Utc>::from),
-            
-            #[cfg(unix)]
-            unix: Some(UnixMetadata {
-                permissions: meta.mode(),
-                uid: meta.uid(),
-                gid: meta.gid(),
-            }),
-            #[cfg(windows)]
-            unix: None,
-
-            #[cfg(windows)]
-            windows: Some(WindowsMetadata {
-                attributes: meta.file_attributes(),
-            }),
-            #[cfg(unix)]
-            windows: None,
         }
+
+        let file = curr_node
+            .files
+            .get(&file)
+            .ok_or_else(|| UpdateErr::FileNotFound)?;
+        let file = file.clone();
+        let res = file.file_ref.write().unwrap().add_tag(tag.clone());
+
+        if res {
+            for (pbuf, mut node) in node_v.into_iter().rev() {
+                node.attach(tag.clone(), file.clone());
+                let child = std::mem::replace(&mut curr_node, node);
+                curr_node.directories.insert(pbuf, child);
+            }
+        }
+
+        self.root = curr_node;
+        Ok(res)
+    }
+
+    pub fn detach(&self, file: Option<PathBuf>, tag: TagRef) -> Result<bool, UpdateErr> {
+        todo!();
     }
 }
 
+// TODO: define extensive errors
 #[derive(Debug)]
-pub struct File {
-    path: PathBuf,
-    hash: u64,
-    metadata: FileMetadata,
-    tags: BTreeSet<&'static Tag>,
-    dir_tags: BTreeSet<&'static Tag>,
-}
-
-#[derive(Debug)]
-pub struct Query {}
-
-// TODO: define appropriate errors, include I/O, etc.
-pub enum QueryErr {
-    SyntaxError, // The Query is incorrectly formatted
-    KeyError,    // The Query uses tags which do not exist in the Shelf
-}
-
-// TODO: define appropriate errors
 pub enum UpdateErr {
     PathNotFound,
-}
-
-impl File {
-    pub fn new(
-        path: PathBuf,
-        tags: BTreeSet<&'static Tag>,
-        dir_tags: BTreeSet<&'static Tag>,
-        metadata: FileMetadata,
-    ) -> Self {
-        File {
-            path,
-            hash: 0,
-            metadata,
-            tags,
-            dir_tags,
-        }
-    }
-
-    pub fn add_tag(&mut self, tag: &'static Tag) -> bool {
-        self.tags.insert(tag)
-    }
-
-    pub fn remove_tag(&mut self, tag: Tag) -> bool {
-        self.tags.remove(&tag)
-    }
+    FileNotFound,
 }

--- a/file-manager/src/tag.rs
+++ b/file-manager/src/tag.rs
@@ -1,0 +1,60 @@
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, RwLock};
+
+#[derive(Debug, Eq, PartialOrd, PartialEq, Ord, Hash, Default)]
+pub struct Tag {
+    id: u64,
+    priority: u64,
+    name: String,
+    parent: Option<&'static Tag>, // what ref should we have to parent ?
+}
+
+#[derive(Debug)]
+pub struct TagRef {
+    pub tag_ref: Arc<RwLock<Tag>>,
+}
+
+impl Clone for TagRef {
+    fn clone(&self) -> Self {
+        TagRef {
+            tag_ref: Arc::clone(&self.tag_ref),
+        }
+    }
+}
+
+impl PartialEq for TagRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.tag_ref.read().unwrap().id == other.tag_ref.read().unwrap().id
+    }
+}
+
+impl PartialOrd for TagRef {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(
+            self.tag_ref
+                .read()
+                .unwrap()
+                .priority
+                .cmp(&other.tag_ref.read().unwrap().priority),
+        )
+    }
+}
+
+impl Hash for TagRef {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.tag_ref.read().unwrap().id.hash(state);
+    }
+}
+
+impl Ord for TagRef {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.tag_ref
+            .read()
+            .unwrap()
+            .priority
+            .cmp(&other.tag_ref.read().unwrap().priority)
+    }
+}
+
+impl Eq for TagRef {}

--- a/file-manager/src/workspace/mod.rs
+++ b/file-manager/src/workspace/mod.rs
@@ -1,0 +1,1 @@
+pub mod workspace;


### PR DESCRIPTION
### Changes
- implemented `attach` for `Shelf`, which attaches a tag to specific
  file by correctly iterating through the nodes
- moved `File`, `Query`, `Tag`, `Node` into their own modules
- implemented `FileRef`, which holds the singlethread ref `Rc<RwLock<File>>` and impls
  `Ord`, `Eq` traits
- implemented `TagRef`, which holds the thread-safe ref `Arc<RwLock<Tag>>` and impls
  `Ord`, `Eq`, `Hash` traits
### Motivation
We need a thread-safe `Arc` reference to tags, because the same `Tag` can be shared between different `Shelf`, that are meant to be ran on different threads. We use `Tag` in HashSet/BTreeSet of `Nodes`/`Files` so we need to implement the traits `Ord`, `Eq`, `Hash`.
Likewise for `File`, except they are wrapped in `Rc` because a file can only be in a single `Shelf` at a time, which runs operations on the same thread.
