### PR TITLE
feat(core): implement `Query`

### DIFF
--- a/file-manager/Cargo.lock
+++ b/file-manager/Cargo.lock
@@ -52,16 +52,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -76,6 +76,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "fxhash",
+ "peg",
 ]
 
 [[package]]
@@ -146,6 +147,33 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "peg"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9928cfca101b36ec5163e70049ee5368a8a1c3c6efc9ca9c5f9cc2f816152477"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6298ab04c202fa5b5d52ba03269fb7b74550b150323038878fe6c372d8280f71"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "132dca9b868d927b35b5dd728167b2dee150eb1ad686008fc71ccb298b776fca"
 
 [[package]]
 name = "proc-macro2"
@@ -260,6 +288,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-targets"

--- a/file-manager/Cargo.toml
+++ b/file-manager/Cargo.toml
@@ -5,5 +5,6 @@ edition = "2021"
 
 [dependencies]
 fxhash = "0.2.1"
-chrono = "0.4.39"
+chrono = "0.4.40"
 #serde = { version = "1.0.218", features = ["derive"] }
+peg = "0.8.5"

--- a/file-manager/src/main.rs
+++ b/file-manager/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::tag::{Tag, TagRef};
 use shelf::shelf::Shelf;
 use std::path::PathBuf;
@@ -8,20 +10,49 @@ mod shelf;
 mod tag;
 
 fn main() {
+    let path = PathBuf::from(".\\A\\B\\C\\D\\E\\File.txt");
+    let stripped_path = path.strip_prefix(".").unwrap().parent();
+
+    println!("{:?}", stripped_path);
+
+    println!("Components");
+    // if stripped_path is none, file must be self.root
+    if let Some(path) = stripped_path {
+        for dir in path.components() {
+            let dir: PathBuf = dir.as_os_str().into();
+            println!("{:?}", dir);
+
+            if dir.as_os_str().is_empty() {
+                continue;
+            }
+        }
+    }
+
+    println!("Ancestors");
+    // if stripped_path is none, file must be self.root
+    if let Some(path) = stripped_path {
+        for dir in path.ancestors().next().unwrap() {
+            println!("{:?}", dir);
+
+            if dir.is_empty() {
+                continue;
+            }
+        }
+    }
     // Test
     //Shelf::new(PathBuf::from("C:\\Users\\Alessandro\\Desktop\\Projects\\Tag-Based File Manager\\Automated Test Procedures\\Tests\\Workspaces\\Generated\\Directory"));
-//    let mut shelf = Shelf::new(PathBuf::from(
-//        "/home/yamabiko/Projects/ebi/Automated Test Procedures/Tests/Workspaces/Generated/Test/",
-//    ))
-//    .unwrap();
-//    let tag = Tag::default();
-//
-//    let tref = TagRef {
-//        tag_ref: Arc::new(RwLock::new(tag)),
-//    };
-//
-//    let file = PathBuf::from("/home/yamabiko/Projects/ebi/Automated Test Procedures/Tests/Workspaces/Generated/Test/4EZ3WpsO/hiLQFdlc.dat");
-//    if let Err(e) = shelf.attach(file, tref) {
-//        eprintln!("{:?}", e);
-//    }
+    //    let mut shelf = Shelf::new(PathBuf::from(
+    //        "/home/yamabiko/Projects/ebi/Automated Test Procedures/Tests/Workspaces/Generated/Test/",
+    //    ))
+    //    .unwrap();
+    //    let tag = Tag::default();
+    //
+    //    let tref = TagRef {
+    //        tag_ref: Arc::new(RwLock::new(tag)),
+    //    };
+    //
+    //    let file = PathBuf::from("/home/yamabiko/Projects/ebi/Automated Test Procedures/Tests/Workspaces/Generated/Test/4EZ3WpsO/hiLQFdlc.dat");
+    //    if let Err(e) = shelf.attach(file, tref) {
+    //        eprintln!("{:?}", e);
+    //    }
 }

--- a/file-manager/src/query.rs
+++ b/file-manager/src/query.rs
@@ -1,8 +1,539 @@
+use crate::shelf::file::{FileMetadata, FileRef};
+use crate::tag::{TagManager, TagRef};
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::fmt::Binary;
+use std::path::PathBuf;
+use std::result;
+
 #[derive(Debug)]
-pub struct Query {}
+pub enum Order {
+    Ascending,
+    Descending,
+}
+
+pub trait FileOrder {}
+
+#[derive(Debug)]
+pub struct Name {
+    pub order: Order,
+}
+
+impl FileOrder for Name {}
+
+#[derive(Debug)]
+pub struct Size {
+    pub order: Order,
+}
+
+impl FileOrder for Size {}
+
+#[derive(Debug)]
+pub struct Modified {
+    pub order: Order,
+}
+
+impl FileOrder for Modified {}
+
+#[derive(Debug)]
+pub struct Created {
+    pub order: Order,
+}
+
+impl FileOrder for Created {}
+
+#[derive(Debug)]
+pub struct Accessed {
+    pub order: Order,
+}
+
+impl FileOrder for Accessed {}
+
+#[derive(Debug)]
+pub struct Unordered;
+
+impl FileOrder for Unordered {}
+
+peg::parser! {
+    grammar tag_query() for str {
+        pub rule expression() -> Formula
+            = precedence! {
+                x:(@) _ "OR" _ y:@ { Formula::BinaryExpression((BinaryOp::OR), (Box::new(x)), (Box::new(y))) }
+                --
+                x:(@) _ "XOR" _ y:@ { Formula::BinaryExpression((BinaryOp::XOR), (Box::new(x)), (Box::new(y))) }
+                --
+                x:(@) _ "AND" _ y:@ { Formula::BinaryExpression((BinaryOp::AND), (Box::new(x)), (Box::new(y))) }
+                --
+                "NOT" _ x:@ { Formula::UnaryExpression((UnaryOp::NOT), (Box::new(x))) }
+                --
+                t:term() {
+                    Formula::Proposition(Proposition { tag: TagManager::retrieve_tag(t) })
+                }
+                --
+                "(" _ e:expression() _ ")" { e }
+            }
+
+        rule term() -> &'input str
+            = "\"" t:$([^ '"']+) "\"" { t }
+
+        rule _() = quiet!{[' ' | '\t' | '\n']*} // Ignore spaces, tabs, and newlines
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Formula {
+    Proposition(Proposition),
+    BinaryExpression(BinaryOp, Box<Formula>, Box<Formula>),
+    UnaryExpression(UnaryOp, Box<Formula>),
+}
+
+#[derive(Debug, Clone)]
+enum BinaryOp {
+    AND,
+    OR,
+    XOR,
+}
+#[derive(Debug, Clone)]
+enum UnaryOp {
+    NOT,
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+struct Proposition {
+    tag: Option<TagRef>,
+}
+
+#[derive(Debug, Clone)]
+struct PeerID {
+    id: String, //[!] Should be a UUID 
+}
+
+#[derive(Debug, Clone)]
+pub struct OrderedFileID<FileOrder> {
+    file_id: FileID,
+    order: FileOrder,
+}
+
+impl PartialEq for OrderedFileID<Name> {
+    fn eq(&self, other: &Self) -> bool {
+        self.file_id.path.file_name() == other.file_id.path.file_name() //[!] path.file_name() is an Option (can, theoretically, be None)
+    }
+}
+
+impl Eq for OrderedFileID<Name> {}
+
+impl PartialOrd for OrderedFileID<Name> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(
+            self.file_id
+                .path
+                .file_name()
+                .unwrap()
+                .cmp(other.file_id.path.file_name().unwrap()),
+        )
+    }
+}
+
+impl Ord for OrderedFileID<Name> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.file_id
+            .path
+            .file_name()
+            .unwrap()
+            .cmp(other.file_id.path.file_name().unwrap())
+    }
+}
+
+impl PartialEq for OrderedFileID<Size> {
+    fn eq(&self, other: &Self) -> bool {
+        self.file_id.metadata.size == other.file_id.metadata.size
+    }
+}
+
+impl Eq for OrderedFileID<Size> {}
+
+impl PartialOrd for OrderedFileID<Size> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.file_id.metadata.size.cmp(&other.file_id.metadata.size))
+    }
+}
+
+impl Ord for OrderedFileID<Size> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.file_id.metadata.size.cmp(&other.file_id.metadata.size)
+    }
+}
+
+impl PartialEq for OrderedFileID<Modified> {
+    fn eq(&self, other: &Self) -> bool {
+        self.file_id.metadata.modified == other.file_id.metadata.modified
+    }
+}
+
+impl Eq for OrderedFileID<Modified> {}
+
+impl PartialOrd for OrderedFileID<Modified> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(
+            self.file_id
+                .metadata
+                .modified
+                .cmp(&other.file_id.metadata.modified),
+        )
+    }
+}
+
+impl Ord for OrderedFileID<Modified> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.file_id
+            .metadata
+            .modified
+            .cmp(&other.file_id.metadata.modified)
+    }
+}
+
+impl PartialEq for OrderedFileID<Created> {
+    fn eq(&self, other: &Self) -> bool {
+        self.file_id.metadata.created == other.file_id.metadata.created
+    }
+}
+
+impl Eq for OrderedFileID<Created> {}
+
+impl PartialOrd for OrderedFileID<Created> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(
+            self.file_id
+                .metadata
+                .created
+                .cmp(&other.file_id.metadata.created),
+        )
+    }
+}
+
+impl Ord for OrderedFileID<Created> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.file_id
+            .metadata
+            .created
+            .cmp(&other.file_id.metadata.created)
+    }
+}
+
+impl PartialEq for OrderedFileID<Accessed> {
+    fn eq(&self, other: &Self) -> bool {
+        self.file_id.metadata.accessed == other.file_id.metadata.accessed
+    }
+}
+
+impl Eq for OrderedFileID<Accessed> {}
+
+impl PartialOrd for OrderedFileID<Accessed> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(
+            self.file_id
+                .metadata
+                .accessed
+                .cmp(&other.file_id.metadata.accessed),
+        )
+    }
+}
+
+impl Ord for OrderedFileID<Accessed> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.file_id
+            .metadata
+            .accessed
+            .cmp(&other.file_id.metadata.accessed)
+    }
+}
+
+impl PartialEq for OrderedFileID<Unordered> {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for OrderedFileID<Unordered> {}
+
+impl PartialOrd for OrderedFileID<Unordered> {
+    fn partial_cmp(&self, _other: &Self) -> Option<std::cmp::Ordering> {
+        Some(std::cmp::Ordering::Equal)
+    }
+}
+
+impl Ord for OrderedFileID<Unordered> {
+    fn cmp(&self, _other: &Self) -> std::cmp::Ordering {
+        std::cmp::Ordering::Equal
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FileID {
+    root: Option<PeerID>, //[/] Whether the file is local or remote
+    path: PathBuf,
+    metadata: FileMetadata,
+}
+
+impl FileID {
+    fn new(root: Option<PeerID>, path: PathBuf, metadata: FileMetadata) -> Self {
+        FileID {
+            root,
+            path,
+            metadata,
+        }
+    }
+}
+
+pub struct Query<T: FileOrder + Clone> {
+    formula: Formula,
+    order: T,
+    result: Option<BTreeSet<OrderedFileID<T>>>
+}
+
+impl<T: FileOrder + Clone> Query<T> {
+    pub fn new(query: &str, order: T) -> Result<Self, QueryErr> {
+        let formula = tag_query::expression(query).or_else(|_err| Err(QueryErr::SyntaxError))?;
+        Ok(Query {
+            formula,
+            order,
+            result: None
+        })
+    }
+
+    pub fn evaluate(&mut self) -> Result<BTreeSet<OrderedFileID<T>>, QueryErr>
+    where
+        OrderedFileID<T>: Ord,
+    {
+        self.simplify();
+        Query::recursive_evaluate(self.formula.clone())
+    }
+
+    fn recursive_evaluate(formula: Formula) -> Result<BTreeSet<OrderedFileID<T>>, QueryErr>
+    where
+        OrderedFileID<T>: Ord,
+    {
+        match formula {
+            Formula::BinaryExpression(BinaryOp::AND, x, y) => match (*x.clone(), *y.clone()) {
+                (_, Formula::UnaryExpression(UnaryOp::NOT, b)) => {
+                    let a = Query::recursive_evaluate(*x.clone())?;
+                    let b = Query::recursive_evaluate(*b.clone())?;
+                    let x: BTreeSet<OrderedFileID<T>> = a.difference(&b).cloned().collect();
+                    Ok(x)
+                }
+                (Formula::UnaryExpression(UnaryOp::NOT, a), _) => {
+                    let a = Query::recursive_evaluate(*a.clone())?;
+                    let b = Query::recursive_evaluate(*y.clone())?;
+                    let x: BTreeSet<OrderedFileID<T>> = b.difference(&a).cloned().collect();
+                    Ok(x)
+                }
+                (a, b) => {
+                    let a = Query::recursive_evaluate(a.clone())?;
+                    let b = Query::recursive_evaluate(b.clone())?;
+                    let x: BTreeSet<OrderedFileID<T>> = a.intersection(&b).cloned().collect();
+                    Ok(x)
+                }
+            },
+            Formula::BinaryExpression(BinaryOp::OR, x, y) => {
+                let a = Query::recursive_evaluate(*x.clone())?;
+                let b = Query::recursive_evaluate(*y.clone())?;
+                let x: BTreeSet<OrderedFileID<T>> = a.union(&b).cloned().collect();
+                Ok(x)
+            }
+            Formula::BinaryExpression(BinaryOp::XOR, x, y) => {
+                let a = Query::recursive_evaluate(*x.clone())?;
+                let b = Query::recursive_evaluate(*y.clone())?;
+                let x: BTreeSet<OrderedFileID<T>> = a.symmetric_difference(&b).cloned().collect();
+                Ok(x)
+            }
+            Formula::UnaryExpression(UnaryOp::NOT, x) => {
+                let a = MockCacheService::get_all()?;
+                let b = Query::recursive_evaluate(*x.clone())?;
+                let x: BTreeSet<OrderedFileID<T>> = a.difference(&b).cloned().collect();
+                Ok(x)
+            }
+            Formula::Proposition(p) => {
+                if let Some(tag) = p.tag {
+                    MockCacheService::get_files(tag.clone()).map_err(|_| QueryErr::KeyError)
+                } else {
+                    return Err(QueryErr::KeyError);
+                }
+            }
+        }
+    }
+
+    fn simplify(&mut self) -> () {
+        loop {
+            let simplified_formula = Formula::recursive_simplify(self.formula.clone());
+            self.formula = simplified_formula.0;
+            if simplified_formula.1 {
+                break;
+            }
+        }
+    }
+}
+
+impl Formula {
+    fn recursive_simplify(formula: Formula) -> (Formula, bool) {
+        //[/] Further simplification is possible but NP-Hard 
+        match formula {
+            Formula::Proposition(_) => {
+                return (formula, false);
+            }
+            Formula::BinaryExpression(BinaryOp::AND, x, y) => match *x.clone() {
+                // De Morgan's Law (AND)
+                Formula::UnaryExpression(UnaryOp::NOT, a) => match *y {
+                    Formula::UnaryExpression(UnaryOp::NOT, b) => (
+                        Formula::UnaryExpression(
+                            UnaryOp::NOT,
+                            Box::new(Formula::BinaryExpression(
+                                BinaryOp::OR,
+                                Box::new(Formula::recursive_simplify(*a).0),
+                                Box::new(Formula::recursive_simplify(*b).0),
+                            )),
+                        ),
+                        true,
+                    ),
+                    _ => {
+                        let simplified_x = Formula::recursive_simplify(*x.clone());
+                        let simplified_y = Formula::recursive_simplify(*y.clone());
+                        (
+                            Formula::BinaryExpression(
+                                BinaryOp::AND,
+                                Box::new(simplified_x.0),
+                                Box::new(simplified_y.0),
+                            ),
+                            simplified_x.1 || simplified_y.1,
+                        )
+                    }
+                },
+                _ => {
+                    let simplified_x = Formula::recursive_simplify(*x.clone());
+                    let simplified_y = Formula::recursive_simplify(*y.clone());
+                    (
+                        Formula::BinaryExpression(
+                            BinaryOp::AND,
+                            Box::new(simplified_x.0),
+                            Box::new(simplified_y.0),
+                        ),
+                        simplified_x.1 || simplified_y.1,
+                    )
+                }
+            },
+            Formula::BinaryExpression(BinaryOp::OR, x, y) => match *x.clone() {
+                // De Morgan's Law (OR)
+                Formula::UnaryExpression(UnaryOp::NOT, a) => match *y {
+                    Formula::UnaryExpression(UnaryOp::NOT, b) => (
+                        Formula::UnaryExpression(
+                            UnaryOp::NOT,
+                            Box::new(Formula::BinaryExpression(
+                                BinaryOp::AND,
+                                Box::new(Formula::recursive_simplify(*a).0),
+                                Box::new(Formula::recursive_simplify(*b).0),
+                            )),
+                        ),
+                        true,
+                    ),
+                    _ => {
+                        let simplified_x = Formula::recursive_simplify(*x.clone());
+                        let simplified_y = Formula::recursive_simplify(*y.clone());
+                        (
+                            Formula::BinaryExpression(
+                                BinaryOp::OR,
+                                Box::new(simplified_x.0),
+                                Box::new(simplified_y.0),
+                            ),
+                            simplified_x.1 || simplified_y.1,
+                        )
+                    }
+                },
+                _ => {
+                    let simplified_x = Formula::recursive_simplify(*x.clone());
+                    let simplified_y = Formula::recursive_simplify(*y.clone());
+                    (
+                        Formula::BinaryExpression(
+                            BinaryOp::OR,
+                            Box::new(simplified_x.0),
+                            Box::new(simplified_y.0),
+                        ),
+                        simplified_x.1 || simplified_y.1,
+                    )
+                }
+            },
+            Formula::BinaryExpression(BinaryOp::XOR, x, y) => match *x.clone() {
+                // (NOT A) XOR (NOT B) ⊨ A XOR B
+                Formula::UnaryExpression(UnaryOp::NOT, a) => match *y {
+                    Formula::UnaryExpression(UnaryOp::NOT, b) => (
+                        Formula::BinaryExpression(
+                            BinaryOp::XOR,
+                            Box::new(Formula::recursive_simplify(*a).0),
+                            Box::new(Formula::recursive_simplify(*b).0),
+                        ),
+                        true,
+                    ),
+                    _ => {
+                        let simplified_x = Formula::recursive_simplify(*x.clone());
+                        let simplified_y = Formula::recursive_simplify(*y.clone());
+                        (
+                            Formula::BinaryExpression(
+                                BinaryOp::XOR,
+                                Box::new(simplified_x.0),
+                                Box::new(simplified_y.0),
+                            ),
+                            simplified_x.1 || simplified_y.1,
+                        )
+                    }
+                },
+                _ => {
+                    let simplified_x = Formula::recursive_simplify(*x.clone());
+                    let simplified_y = Formula::recursive_simplify(*y.clone());
+                    (
+                        Formula::BinaryExpression(
+                            BinaryOp::XOR,
+                            Box::new(simplified_x.0),
+                            Box::new(simplified_y.0),
+                        ),
+                        simplified_x.1 || simplified_y.1,
+                    )
+                }
+            },
+            Formula::UnaryExpression(UnaryOp::NOT, x) => match *x {
+                // NOT (NOT A) ⊨ A
+                Formula::UnaryExpression(UnaryOp::NOT, y) => {
+                    (Formula::recursive_simplify(*y).0, true)
+                }
+                _ => {
+                    let simplified_x = Formula::recursive_simplify(*x.clone());
+                    (
+                        Formula::UnaryExpression(UnaryOp::NOT, Box::new(simplified_x.0)),
+                        simplified_x.1,
+                    )
+                }
+            },
+        }
+    }
+}
 
 // TODO: define appropriate errors, include I/O, etc.
 pub enum QueryErr {
     SyntaxError, // The Query is incorrectly formatted
-    KeyError,    // The Query uses tags which do not exist in the Shelf
+    KeyError,    // The Query uses tags which do not exist
+}
+
+//[!] Placeholder for CacheService 
+
+pub struct MockCacheService {}
+
+impl MockCacheService {
+    pub fn new() -> Self {
+        MockCacheService {}
+    }
+
+    pub fn get_files<T: FileOrder>(tag: TagRef) -> Result<BTreeSet<OrderedFileID<T>>, QueryErr> {
+        todo!();
+    }
+
+    pub fn get_all<T: FileOrder>() -> Result<BTreeSet<OrderedFileID<T>>, QueryErr> {
+        todo!();
+    }
 }

--- a/file-manager/src/shelf/file.rs
+++ b/file-manager/src/shelf/file.rs
@@ -24,25 +24,25 @@ pub struct File {
     dtags: BTreeSet<TagRef>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FileMetadata {
-    size: u64,
-    readonly: bool,
-    modified: Option<DateTime<Utc>>,
-    accessed: Option<DateTime<Utc>>,
-    created: Option<DateTime<Utc>>,
-    unix: Option<UnixMetadata>,
-    windows: Option<WindowsMetadata>,
+    pub size: u64,
+    pub readonly: bool,
+    pub modified: Option<DateTime<Utc>>,
+    pub accessed: Option<DateTime<Utc>>,
+    pub created: Option<DateTime<Utc>>,
+    pub unix: Option<UnixMetadata>,
+    pub windows: Option<WindowsMetadata>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct UnixMetadata {
     permissions: u32,
     uid: u32,
     gid: u32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct WindowsMetadata {
     attributes: u32,
 }

--- a/file-manager/src/shelf/mod.rs
+++ b/file-manager/src/shelf/mod.rs
@@ -1,3 +1,3 @@
-mod file;
+pub mod file;
 mod node;
 pub mod shelf;

--- a/file-manager/src/shelf/shelf.rs
+++ b/file-manager/src/shelf/shelf.rs
@@ -25,11 +25,24 @@ impl Shelf {
         })
     }
 
-    pub async fn refresh(&self) -> Result<bool, io::Error> {
-        todo!();
+    pub async fn retrieve(&self, tag: TagRef) -> BTreeSet<FileRef> {
+        let mut res = self
+            .root
+            .tags
+            .get(&tag)
+            .cloned()
+            .unwrap_or_else(|| BTreeSet::<FileRef>::new());
+        let mut dres = self
+            .root
+            .dtag_files
+            .get(&tag)
+            .cloned()
+            .unwrap_or_else(|| BTreeSet::<FileRef>::new());
+        res.append(&mut dres);
+        res
     }
 
-    pub fn query(&self, query: Query) -> Result<Vec<&'static File>, QueryErr> {
+    pub async fn refresh(&self) -> Result<bool, io::Error> {
         todo!();
     }
 
@@ -301,7 +314,7 @@ impl Shelf {
                             node.dtag_files.remove(&dtag);
                         }
                     }
-                    None => (), //[!] Critical Internal Error 
+                    None => (), //[!] Critical Internal Error
                 }
             }
 
@@ -321,7 +334,7 @@ impl Shelf {
                     let child = std::mem::replace(&mut curr_node, node);
                     curr_node.directories.insert(pbuf, child);
                 }
-                None => (), //[!] Internal Error 
+                None => (), //[!] Internal Error
             }
         }
 
@@ -333,7 +346,7 @@ impl Shelf {
     }
 }
 
-// [TODO]: define extensive errors 
+// [TODO]: define extensive errors
 #[derive(Debug)]
 pub enum UpdateErr {
     PathNotFound,

--- a/file-manager/src/tag.rs
+++ b/file-manager/src/tag.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, RwLock};
 
@@ -58,3 +59,17 @@ impl Ord for TagRef {
 }
 
 impl Eq for TagRef {}
+
+//[#] We require a tag manmager
+pub struct TagManager {
+    tags: HashMap<String, TagRef>,
+}
+
+impl TagManager {
+    pub fn retrieve_tag(name: &str) -> Option<TagRef> {
+        println!("Retrieving tag {}", name);
+        return Some(TagRef {
+            tag_ref: Arc::new(RwLock::new(Tag::default())),
+        });
+    }
+}


### PR DESCRIPTION
- implemented `simplify` for `Query`, which removes redundant complexity (double negation, De Morgan's law, ...)
- implemented `evaluate` for `Query`, which returns a set of (ordered) `FileID`s that satisfy the query
- implemented structs required for `Query` to function as designed